### PR TITLE
Made tool search bwa version agnostic

### DIFF
--- a/page_perf_timer.py
+++ b/page_perf_timer.py
@@ -148,14 +148,14 @@ class PagePerfTimer(object):
         # Wait for BWA tool to appear
         self.wait.until(expected_conditions.presence_of_element_located(
             (By.XPATH,
-             "//a[@href='/tool_runner?tool_id=toolshed.g2.bx.psu.edu%2Frepos%2Fdevteam%2Fbwa%2Fbwa%2F0.7.17.4']")))
+             "//a[starts-with(@href, '/tool_runner?tool_id=toolshed.g2.bx.psu.edu%2Frepos%2Fdevteam%2Fbwa%2Fbwa%2F0.7')]")))
 
     @clock_action("tool_form_load")
     def load_tool_form(self):
         # Select BWA tool
         bwa_tool = self.driver.find_element(
             By.XPATH,
-            "//a[@href='/tool_runner?tool_id=toolshed.g2.bx.psu.edu%2Frepos%2Fdevteam%2Fbwa%2Fbwa%2F0.7.17.4']")
+            "//a[starts-with(@href,'/tool_runner?tool_id=toolshed.g2.bx.psu.edu%2Frepos%2Fdevteam%2Fbwa%2Fbwa%2F0.7')]")
         bwa_tool.click()
         # Wait for tool form to load and execute button to appear
         self.wait.until(expected_conditions.presence_of_element_located((By.ID, "execute")))


### PR DESCRIPTION
BWA on Galaxy Aus is 0.7.17.5 whereas on .eu and .org it is 0.7.17.4.. page_perf_timer.py looks for an exact version (0.7.17.4). This PR should make it a bit more version agnostic by using "starts-with" in By.XPATH..