### PR TITLE
Update page_performance_timer for new login behaviour and tool search result matching

### DIFF
--- a/page_perf_timer.py
+++ b/page_perf_timer.py
@@ -139,7 +139,9 @@ class PagePerfTimer(object):
     def find_login_button(self):
         with SeleniumCustomWait(self.driver, 0):
             try:
-                return self.driver.find_element(By.NAME, "login")
+                return self.driver.find_element(
+                    By.XPATH, "//input[@name='login' or @name='username' or @id='username']"
+                )
             except NoSuchElementException:
                 return None
 
@@ -152,11 +154,11 @@ class PagePerfTimer(object):
             except NoSuchElementException:
                 return None
 
-    def find_biocommons_login_button(self):
+    def find_password_input(self):
         with SeleniumCustomWait(self.driver, 0):
             try:
                 return self.driver.find_element(
-                    By.XPATH, "//button[contains(., 'BioCommons Access')]"
+                    By.XPATH, "//input[@name='password' or @id='password']"
                 )
             except NoSuchElementException:
                 return None
@@ -165,8 +167,6 @@ class PagePerfTimer(object):
         if self.find_login_button():
             return True
         elif self.find_sign_in_with_email():
-            return True
-        elif self.find_biocommons_login_button():
             return True
         else:
             return False
@@ -202,35 +202,25 @@ class PagePerfTimer(object):
             )
         )
 
-    def login_with_biocommons(self):
-        self.find_biocommons_login_button().click()
-        self.wait.until(
-            expected_conditions.presence_of_element_located((By.ID, "username"))
-        ).send_keys(self.username)
-        password_input = self.driver.find_element(By.ID, "password")
-        password_input.send_keys(self.password)
-        password_input.send_keys(Keys.ENTER)
-
-    def login_with_galaxy_internal_login(self):
+    def login_with_username_and_password(self):
         elem = self.find_sign_in_with_email()
-        # if sign in with email is available, this is galaxy-au's customised page.
+        # Log in page contains username and password fields from Galaxy or from Biocommmons Access
         if elem:
             elem.click()
-        # Click username textbox
-        self.driver.find_element(By.NAME, "login").click()
+        username_input = self.wait.until(lambda driver: self.find_login_button())
+        password_input = self.wait.until(lambda driver: self.find_password_input())
         # Type in username
-        self.driver.find_element(By.NAME, "login").send_keys(self.username)
+        username_input.clear()
+        username_input.send_keys(self.username)
         # Type in password
-        self.driver.find_element(By.NAME, "password").send_keys(self.password)
+        password_input.clear()
+        password_input.send_keys(self.password)
         # Submit login form
-        self.driver.find_element(By.NAME, "password").send_keys(Keys.ENTER)
+        password_input.send_keys(Keys.ENTER)
 
     @clock_action("home_page_load")
     def login_to_galaxy_homepage(self):
-        if self.find_biocommons_login_button():
-            self.login_with_biocommons()
-        else:
-            self.login_with_galaxy_internal_login()
+        self.login_with_username_and_password()
         self.wait_for_galaxy_homepage()
 
     @clock_action("dummy_file_upload")
@@ -305,7 +295,7 @@ class PagePerfTimer(object):
             expected_conditions.presence_of_element_located(
                 (
                     By.XPATH,
-                    "//a[starts-with(@href, '/tool_runner?tool_id=toolshed.g2.bx.psu.edu%2Frepos%2Fdevteam%2Fbwa%2Fbwa%2F0.7')]",
+                    "//a[starts-with(@data-tool-id, 'toolshed.g2.bx.psu.edu/repos/devteam/bwa/bwa/0.7')]",
                 )
             )
         )
@@ -315,7 +305,7 @@ class PagePerfTimer(object):
         # Select BWA tool
         bwa_tool = self.driver.find_element(
             By.XPATH,
-            "//a[starts-with(@href,'/tool_runner?tool_id=toolshed.g2.bx.psu.edu%2Frepos%2Fdevteam%2Fbwa%2Fbwa%2F0.7')]",
+            "//a[starts-with(@data-tool-id, 'toolshed.g2.bx.psu.edu/repos/devteam/bwa/bwa/0.7')]",
         )
         bwa_tool.click()
         # Wait for tool form to load and execute button to appear

--- a/page_perf_timer.py
+++ b/page_perf_timer.py
@@ -151,15 +151,6 @@ class PagePerfTimer(object):
             except NoSuchElementException:
                 return None
 
-    def find_sign_in_with_email(self):
-        with SeleniumCustomWait(self.driver, 0):
-            try:
-                return self.driver.find_element(
-                    By.XPATH, "//a[contains(., 'Sign in with email')]"
-                )
-            except NoSuchElementException:
-                return None
-
     def find_galaxy_password_input(self):
         with SeleniumCustomWait(self.driver, 0):
             try:
@@ -173,6 +164,12 @@ class PagePerfTimer(object):
     def find_biocommons_password_input(self):
         return self.find_visible_element("//input[@id='password' or @name='password']")
 
+    def wait_for_login_form(self):
+        self.wait.until(
+            lambda driver: self.find_galaxy_login_input()
+            or self.find_biocommons_login_input()
+        )
+
     def wait_for_history_panel_to_load(self):
         self.wait.until(
             expected_conditions.presence_of_element_located(
@@ -184,6 +181,7 @@ class PagePerfTimer(object):
     def load_galaxy_login(self):
         # Open Galaxy window
         self.driver.get(f"{self.server}/login")
+        self.wait_for_login_form()
 
     def wait_for_galaxy_homepage(self):
         # Wait for tool search box to appear
@@ -212,9 +210,6 @@ class PagePerfTimer(object):
         password_input.send_keys(Keys.ENTER)
 
     def login_with_biocommons_login(self):
-        elem = self.find_sign_in_with_email()
-        if elem:
-            elem.click()
         username_input = self.wait.until(
             lambda driver: self.find_biocommons_login_input()
         )
@@ -229,23 +224,13 @@ class PagePerfTimer(object):
 
     @clock_action("home_page_load")
     def login_to_galaxy_homepage(self):
+        self.wait_for_login_form()
         if self.find_galaxy_login_input():
             self.login_with_galaxy_login()
-        elif self.find_sign_in_with_email() or self.find_biocommons_login_input():
+        elif self.find_biocommons_login_input():
             self.login_with_biocommons_login()
         else:
-            # Let the concrete form selectors decide after the page has had a chance to render.
-            self.wait.until(
-                lambda driver: self.find_galaxy_login_input()
-                or self.find_sign_in_with_email()
-                or self.find_biocommons_login_input()
-            )
-            if self.find_galaxy_login_input():
-                self.login_with_galaxy_login()
-            elif self.find_sign_in_with_email() or self.find_biocommons_login_input():
-                self.login_with_biocommons_login()
-            else:
-                raise RuntimeError("No supported login flow found on the page")
+            raise RuntimeError("No supported login form found on the page")
         self.wait_for_galaxy_homepage()
 
     @clock_action("dummy_file_upload")

--- a/page_perf_timer.py
+++ b/page_perf_timer.py
@@ -136,37 +136,35 @@ class PagePerfTimer(object):
         self.driver.implicitly_wait(180)
         self.wait = WebDriverWait(self.driver, 180)
 
-    def find_login_button(self):
+    def find_visible_element(self, xpath):
         with SeleniumCustomWait(self.driver, 0):
-            try:
-                return self.driver.find_element(
-                    By.XPATH, "//input[@name='login' or @name='username' or @id='username']"
-                )
-            except NoSuchElementException:
-                return None
+            elements = self.driver.find_elements(By.XPATH, xpath)
+            for element in elements:
+                if element.is_displayed() and element.is_enabled():
+                    return element
+            return None
+
+    def find_galaxy_login_input(self):
+        return self.find_visible_element("//input[@name='login']")
 
     def find_sign_in_with_email(self):
-        with SeleniumCustomWait(self.driver, 0):
-            try:
-                return self.driver.find_element(
-                    By.XPATH, "//a[contains(., 'Sign in with email')]"
-                )
-            except NoSuchElementException:
-                return None
+        return self.find_visible_element("//a[contains(., 'Sign in with email')]")
 
-    def find_password_input(self):
-        with SeleniumCustomWait(self.driver, 0):
-            try:
-                return self.driver.find_element(
-                    By.XPATH, "//input[@name='password' or @id='password']"
-                )
-            except NoSuchElementException:
-                return None
+    def find_galaxy_password_input(self):
+        return self.find_visible_element("//input[@name='password']")
+
+    def find_username_or_email_input(self):
+        return self.find_visible_element("//input[@name='username' or @id='username']")
+
+    def find_alternate_password_input(self):
+        return self.find_visible_element("//input[@id='password' or @name='password']")
 
     def is_able_to_login(self, driver):
-        if self.find_login_button():
+        if self.find_galaxy_login_input():
             return True
         elif self.find_sign_in_with_email():
+            return True
+        elif self.find_username_or_email_input():
             return True
         else:
             return False
@@ -202,25 +200,38 @@ class PagePerfTimer(object):
             )
         )
 
-    def login_with_username_and_password(self):
-        elem = self.find_sign_in_with_email()
-        # Log in page contains username and password fields from Galaxy or from Biocommmons Access
-        if elem:
-            elem.click()
-        username_input = self.wait.until(lambda driver: self.find_login_button())
-        password_input = self.wait.until(lambda driver: self.find_password_input())
-        # Type in username
+    def login_with_galaxy_internal_login(self):
+        username_input = self.wait.until(lambda driver: self.find_galaxy_login_input())
+        password_input = self.wait.until(lambda driver: self.find_galaxy_password_input())
         username_input.clear()
         username_input.send_keys(self.username)
-        # Type in password
         password_input.clear()
         password_input.send_keys(self.password)
-        # Submit login form
+        password_input.send_keys(Keys.ENTER)
+
+    def login_with_alternate_login(self):
+        elem = self.find_sign_in_with_email()
+        # Some deployments gate the visible form behind an extra email-login link.
+        if elem:
+            elem.click()
+        username_input = self.wait.until(
+            lambda driver: self.find_username_or_email_input()
+        )
+        password_input = self.wait.until(
+            lambda driver: self.find_alternate_password_input()
+        )
+        username_input.clear()
+        username_input.send_keys(self.username)
+        password_input.clear()
+        password_input.send_keys(self.password)
         password_input.send_keys(Keys.ENTER)
 
     @clock_action("home_page_load")
     def login_to_galaxy_homepage(self):
-        self.login_with_username_and_password()
+        if self.find_sign_in_with_email() or self.find_username_or_email_input():
+            self.login_with_alternate_login()
+        else:
+            self.login_with_galaxy_internal_login()
         self.wait_for_galaxy_homepage()
 
     @clock_action("dummy_file_upload")

--- a/page_perf_timer.py
+++ b/page_perf_timer.py
@@ -161,7 +161,9 @@ class PagePerfTimer(object):
 
     def is_able_to_login(self, driver):
         return bool(
-            self.find_sign_in_with_email() or self.find_galaxy_login_input()
+            self.find_sign_in_with_email()
+            or self.find_galaxy_login_input()
+            or self.find_username_or_email_input()
         )
 
     def wait_for_history_panel_to_load(self):
@@ -223,7 +225,7 @@ class PagePerfTimer(object):
 
     @clock_action("home_page_load")
     def login_to_galaxy_homepage(self):
-        if self.find_sign_in_with_email():
+        if self.find_sign_in_with_email() or self.find_username_or_email_input():
             self.login_with_alternate_login()
         elif self.find_galaxy_login_input():
             self.login_with_galaxy_internal_login()

--- a/page_perf_timer.py
+++ b/page_perf_timer.py
@@ -160,14 +160,9 @@ class PagePerfTimer(object):
         return self.find_visible_element("//input[@id='password' or @name='password']")
 
     def is_able_to_login(self, driver):
-        if self.find_galaxy_login_input():
-            return True
-        elif self.find_sign_in_with_email():
-            return True
-        elif self.find_username_or_email_input():
-            return True
-        else:
-            return False
+        return bool(
+            self.find_sign_in_with_email() or self.find_galaxy_login_input()
+        )
 
     def wait_for_history_panel_to_load(self):
         self.wait.until(
@@ -228,10 +223,12 @@ class PagePerfTimer(object):
 
     @clock_action("home_page_load")
     def login_to_galaxy_homepage(self):
-        if self.find_sign_in_with_email() or self.find_username_or_email_input():
+        if self.find_sign_in_with_email():
             self.login_with_alternate_login()
-        else:
+        elif self.find_galaxy_login_input():
             self.login_with_galaxy_internal_login()
+        else:
+            raise RuntimeError("No supported login flow found on the page")
         self.wait_for_galaxy_homepage()
 
     @clock_action("dummy_file_upload")

--- a/page_perf_timer.py
+++ b/page_perf_timer.py
@@ -144,39 +144,44 @@ class PagePerfTimer(object):
                     return element
             return None
 
-    def find_galaxy_login_input(self):
-        return self.find_visible_element("//input[@name='login']")
+    def find_login_button(self):
+        with SeleniumCustomWait(self.driver, 0):
+            try:
+                return self.driver.find_element(By.NAME, "login")
+            except NoSuchElementException:
+                return None
 
     def find_sign_in_with_email(self):
-        return self.find_visible_element("//a[contains(., 'Sign in with email')]")
+        with SeleniumCustomWait(self.driver, 0):
+            try:
+                return self.driver.find_element(
+                    By.XPATH, "//a[contains(., 'Sign in with email')]"
+                )
+            except NoSuchElementException:
+                return None
 
     def find_galaxy_password_input(self):
-        return self.find_visible_element("//input[@name='password']")
+        with SeleniumCustomWait(self.driver, 0):
+            try:
+                return self.driver.find_element(By.NAME, "password")
+            except NoSuchElementException:
+                return None
 
-    def find_username_or_email_input(self):
+    def find_new_login_input(self):
         return self.find_visible_element("//input[@name='username' or @id='username']")
 
-    def find_alternate_password_input(self):
+    def find_new_password_input(self):
         return self.find_visible_element("//input[@id='password' or @name='password']")
 
-    def is_old_login_available(self):
-        return bool(self.find_galaxy_login_input())
-
-    def is_new_login_available(self):
-        return bool(
-            self.find_sign_in_with_email()
-            or (self.find_username_or_email_input() and not self.find_galaxy_login_input())
-        )
-
-    def get_login_flow(self):
-        if self.is_old_login_available():
-            return "old"
-        if self.is_new_login_available():
-            return "new"
-        return None
-
     def is_able_to_login(self, driver):
-        return bool(self.get_login_flow())
+        if self.find_login_button():
+            return True
+        elif self.find_sign_in_with_email():
+            return True
+        elif self.find_new_login_input():
+            return True
+        else:
+            return False
 
     def wait_for_history_panel_to_load(self):
         self.wait.until(
@@ -189,7 +194,7 @@ class PagePerfTimer(object):
     def load_galaxy_login(self):
         # Open Galaxy window
         self.driver.get(f"{self.server}/login")
-        # Wait for one of the supported login forms to appear.
+        # Wait for a supported login form to appear.
         self.wait.until(self.is_able_to_login)
 
     def wait_for_galaxy_homepage(self):
@@ -210,7 +215,7 @@ class PagePerfTimer(object):
         )
 
     def login_with_galaxy_internal_login(self):
-        username_input = self.wait.until(lambda driver: self.find_galaxy_login_input())
+        username_input = self.wait.until(lambda driver: self.find_login_button())
         password_input = self.wait.until(lambda driver: self.find_galaxy_password_input())
         username_input.clear()
         username_input.send_keys(self.username)
@@ -220,15 +225,10 @@ class PagePerfTimer(object):
 
     def login_with_alternate_login(self):
         elem = self.find_sign_in_with_email()
-        # Some deployments gate the visible form behind an extra email-login link.
         if elem:
             elem.click()
-        username_input = self.wait.until(
-            lambda driver: self.find_username_or_email_input()
-        )
-        password_input = self.wait.until(
-            lambda driver: self.find_alternate_password_input()
-        )
+        username_input = self.wait.until(lambda driver: self.find_new_login_input())
+        password_input = self.wait.until(lambda driver: self.find_new_password_input())
         username_input.clear()
         username_input.send_keys(self.username)
         password_input.clear()
@@ -237,11 +237,10 @@ class PagePerfTimer(object):
 
     @clock_action("home_page_load")
     def login_to_galaxy_homepage(self):
-        login_flow = self.get_login_flow()
-        if login_flow == "new":
-            self.login_with_alternate_login()
-        elif login_flow == "old":
+        if self.find_login_button():
             self.login_with_galaxy_internal_login()
+        elif self.find_sign_in_with_email() or self.find_new_login_input():
+            self.login_with_alternate_login()
         else:
             raise RuntimeError("No supported login flow found on the page")
         self.wait_for_galaxy_homepage()

--- a/page_perf_timer.py
+++ b/page_perf_timer.py
@@ -159,12 +159,24 @@ class PagePerfTimer(object):
     def find_alternate_password_input(self):
         return self.find_visible_element("//input[@id='password' or @name='password']")
 
-    def is_able_to_login(self, driver):
+    def is_old_login_available(self):
+        return bool(self.find_galaxy_login_input())
+
+    def is_new_login_available(self):
         return bool(
             self.find_sign_in_with_email()
-            or self.find_galaxy_login_input()
-            or self.find_username_or_email_input()
+            or (self.find_username_or_email_input() and not self.find_galaxy_login_input())
         )
+
+    def get_login_flow(self):
+        if self.is_old_login_available():
+            return "old"
+        if self.is_new_login_available():
+            return "new"
+        return None
+
+    def is_able_to_login(self, driver):
+        return bool(self.get_login_flow())
 
     def wait_for_history_panel_to_load(self):
         self.wait.until(
@@ -177,7 +189,7 @@ class PagePerfTimer(object):
     def load_galaxy_login(self):
         # Open Galaxy window
         self.driver.get(f"{self.server}/login")
-        # Wait for username entry to appear
+        # Wait for one of the supported login forms to appear.
         self.wait.until(self.is_able_to_login)
 
     def wait_for_galaxy_homepage(self):
@@ -225,9 +237,10 @@ class PagePerfTimer(object):
 
     @clock_action("home_page_load")
     def login_to_galaxy_homepage(self):
-        if self.find_sign_in_with_email() or self.find_username_or_email_input():
+        login_flow = self.get_login_flow()
+        if login_flow == "new":
             self.login_with_alternate_login()
-        elif self.find_galaxy_login_input():
+        elif login_flow == "old":
             self.login_with_galaxy_internal_login()
         else:
             raise RuntimeError("No supported login flow found on the page")

--- a/page_perf_timer.py
+++ b/page_perf_timer.py
@@ -144,7 +144,7 @@ class PagePerfTimer(object):
                     return element
             return None
 
-    def find_login_button(self):
+    def find_galaxy_login_input(self):
         with SeleniumCustomWait(self.driver, 0):
             try:
                 return self.driver.find_element(By.NAME, "login")
@@ -167,18 +167,18 @@ class PagePerfTimer(object):
             except NoSuchElementException:
                 return None
 
-    def find_new_login_input(self):
+    def find_biocommons_login_input(self):
         return self.find_visible_element("//input[@name='username' or @id='username']")
 
-    def find_new_password_input(self):
+    def find_biocommons_password_input(self):
         return self.find_visible_element("//input[@id='password' or @name='password']")
 
     def is_able_to_login(self, driver):
-        if self.find_login_button():
+        if self.find_galaxy_login_input():
             return True
         elif self.find_sign_in_with_email():
             return True
-        elif self.find_new_login_input():
+        elif self.find_biocommons_login_input():
             return True
         else:
             return False
@@ -214,8 +214,8 @@ class PagePerfTimer(object):
             )
         )
 
-    def login_with_galaxy_internal_login(self):
-        username_input = self.wait.until(lambda driver: self.find_login_button())
+    def login_with_galaxy_login(self):
+        username_input = self.wait.until(lambda driver: self.find_galaxy_login_input())
         password_input = self.wait.until(lambda driver: self.find_galaxy_password_input())
         username_input.clear()
         username_input.send_keys(self.username)
@@ -223,12 +223,16 @@ class PagePerfTimer(object):
         password_input.send_keys(self.password)
         password_input.send_keys(Keys.ENTER)
 
-    def login_with_alternate_login(self):
+    def login_with_biocommons_login(self):
         elem = self.find_sign_in_with_email()
         if elem:
             elem.click()
-        username_input = self.wait.until(lambda driver: self.find_new_login_input())
-        password_input = self.wait.until(lambda driver: self.find_new_password_input())
+        username_input = self.wait.until(
+            lambda driver: self.find_biocommons_login_input()
+        )
+        password_input = self.wait.until(
+            lambda driver: self.find_biocommons_password_input()
+        )
         username_input.clear()
         username_input.send_keys(self.username)
         password_input.clear()
@@ -237,10 +241,10 @@ class PagePerfTimer(object):
 
     @clock_action("home_page_load")
     def login_to_galaxy_homepage(self):
-        if self.find_login_button():
-            self.login_with_galaxy_internal_login()
-        elif self.find_sign_in_with_email() or self.find_new_login_input():
-            self.login_with_alternate_login()
+        if self.find_galaxy_login_input():
+            self.login_with_galaxy_login()
+        elif self.find_sign_in_with_email() or self.find_biocommons_login_input():
+            self.login_with_biocommons_login()
         else:
             raise RuntimeError("No supported login flow found on the page")
         self.wait_for_galaxy_homepage()

--- a/page_perf_timer.py
+++ b/page_perf_timer.py
@@ -173,16 +173,6 @@ class PagePerfTimer(object):
     def find_biocommons_password_input(self):
         return self.find_visible_element("//input[@id='password' or @name='password']")
 
-    def is_able_to_login(self, driver):
-        if self.find_galaxy_login_input():
-            return True
-        elif self.find_sign_in_with_email():
-            return True
-        elif self.find_biocommons_login_input():
-            return True
-        else:
-            return False
-
     def wait_for_history_panel_to_load(self):
         self.wait.until(
             expected_conditions.presence_of_element_located(
@@ -194,8 +184,6 @@ class PagePerfTimer(object):
     def load_galaxy_login(self):
         # Open Galaxy window
         self.driver.get(f"{self.server}/login")
-        # Wait for a supported login form to appear.
-        self.wait.until(self.is_able_to_login)
 
     def wait_for_galaxy_homepage(self):
         # Wait for tool search box to appear
@@ -246,7 +234,18 @@ class PagePerfTimer(object):
         elif self.find_sign_in_with_email() or self.find_biocommons_login_input():
             self.login_with_biocommons_login()
         else:
-            raise RuntimeError("No supported login flow found on the page")
+            # Let the concrete form selectors decide after the page has had a chance to render.
+            self.wait.until(
+                lambda driver: self.find_galaxy_login_input()
+                or self.find_sign_in_with_email()
+                or self.find_biocommons_login_input()
+            )
+            if self.find_galaxy_login_input():
+                self.login_with_galaxy_login()
+            elif self.find_sign_in_with_email() or self.find_biocommons_login_input():
+                self.login_with_biocommons_login()
+            else:
+                raise RuntimeError("No supported login flow found on the page")
         self.wait_for_galaxy_homepage()
 
     @clock_action("dummy_file_upload")


### PR DESCRIPTION
Since release_26.0, a user logging in to Galaxy Australia is not faced with the “Log in with biocommons access” button but instead goes straight to the page with fields for username and password, so regardless of whether biocommons access or not, the next step is to fill this form and log in.

The tool links in search results changed, probably also with release_26.0.